### PR TITLE
chore: add OIDC permissions and standardize job name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,12 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   release:
-    name: '/'
+    name: 'Release'
     uses: technology-studio/github-workflows/.github/workflows/_release.yml@main
     secrets: inherit


### PR DESCRIPTION
Add OIDC permissions for npm trusted publishing and standardize job name to Release per boilerplate.